### PR TITLE
[add] mem_limit to mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,4 @@ services:
       - ${MYSQL_DATA_DIR:-./mysql/data}:/var/lib/mysql
       - ./mysql/logs:/var/log/mysql
       - ./mysql/scripts:/scripts
+    mem_limit: 4g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
     # [TODO] user $UID:$GID
+    restart: "unless-stopped"
   mysql:
     container_name: ${CONTAINER_NAME_MYSQL:-nanbyodata-mysql}
     image: mysql:8.0
@@ -34,3 +35,4 @@ services:
       - ./mysql/logs:/var/log/mysql
       - ./mysql/scripts:/scripts
     mem_limit: 4g
+    restart: "unless-stopped"

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -11,3 +11,7 @@ skip-character-set-client-handshake
 character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
 init-connect=SET NAMES utf8mb4
+
+# 一時テーブルなどのメモリリミット
+max_heap_table_size=1G
+tmp_table_size=1G


### PR DESCRIPTION
### 変更目的

* nanbyodata用のmysqlにメモリリミットを付与し、必要以上にリソースを消費しないようにする

### 変更箇所

* docker-compose.yamlのメモリリミット
* docker-compose.yamlのリスタートポリシー
    * もし途中でコンテナが倒れたらリスタートするようにする
* my.cnfのメモリテーブルのメモリリミット
    * 参考: https://dev.mysql.com/doc/refman/8.0/ja/memory-storage-engine.html
    * 開発環境のmysqlのメトリクスを見ると、メモリ使用量が常に1GB以下だったため

<img width="1909" height="902" alt="image" src="https://github.com/user-attachments/assets/19c630e6-74c5-4eaa-8d41-fd51464d26f6" />



### レビューポイント

* [ ] mysqlのメモリリミットに違和感がないか
* [ ] コンテナがリスタートすることによる問題はないか