### PR TITLE
Add NanbyoData docs

### DIFF
--- a/docs/01-system-overview.md
+++ b/docs/01-system-overview.md
@@ -1,0 +1,94 @@
+# NanbyoData システム全体図
+
+## この資料の目的
+
+NanbyoData は、Flask で画面を返す Web アプリと、難病オントロジーや SPARQList クエリ資産を組み合わせた構成です。  
+最初にこの図を見て、「どのコンポーネントが何を担当しているか」「どこが内部資産で、どこが別サービスか」を把握するのがねらいです。
+
+## ひとことで言うと
+
+- `app.py` が Web アプリの入口
+- `templates/` と `static/` が画面側
+- `ontology/` と `annotation/` が配布・参照されるデータ資産
+- `sparqlist/` が API クエリ定義の別サービス資産
+- Docker / uWSGI / nginx が実行基盤
+
+## システム構成図
+
+```mermaid
+flowchart LR
+    user["User Browser"] --> nginx["nginx\n(dev only)"]
+    user --> app
+    nginx --> app["Flask app\napp.py"]
+
+    app --> templates["Jinja templates\ntemplates/"]
+    app --> static["Static assets\nstatic/"]
+    app --> ontology["Ontology files\nontology/"]
+    app --> annotation["Annotation files\nannotation/"]
+    app --> sparqlist_api["SPARQList API\n/sparqlist/api/..."]
+
+    sparqlist_api --> sparqlist_repo["SPARQList repository\nsparqlist/repository/"]
+
+    docker["Docker Compose"] --> app
+    docker --> nginx
+    uwsgi["uWSGI"] --> app
+```
+
+## コンポーネントの役割
+
+### 1. Flask アプリ
+
+- 入口は `app.py`
+- URL ルーティングをまとめて持つ
+- 各ページに対応する HTML テンプレートを返す
+- 疾患詳細ページでは、ontology と SPARQList API の両方を使う
+
+関連ファイル:
+- `app.py`
+- `uwsgi/uwsgi.ini`
+
+### 2. テンプレートと静的アセット
+
+- `templates/` は Jinja2 テンプレート
+- `static/js/` はページごとの振る舞いを持つ JavaScript
+- `static/sass/` と `static/css/` はスタイル
+- `static/img/` は画像やアイコン
+
+ここは「画面の見た目・構造」を理解したいときに読む場所です。
+
+### 3. ontology と annotation
+
+- `ontology/` には NANDO のリリース資産がある
+- `annotation/` には遺伝子や表現型に関する注釈データがある
+- Flask はこれらをダウンロード配布したり、一部をローカル参照したりする
+
+ここは「データの正体」を知りたいときに重要です。
+
+### 4. SPARQList
+
+- `sparqlist/` は SPARQList の運用・設定用ディレクトリ
+- `sparqlist/repository/` に API クエリ定義が入っている
+- Flask 側は `BASE_URI/sparqlist/api/...` を叩いて概要や関連情報を取得する
+
+ここは「どこから API レスポンスが来るのか」を理解したいときに読みます。
+
+### 5. 実行基盤
+
+- `Dockerfile` で Python 3.8 + pipenv + uWSGI を構成
+- `docker-compose.yml` は基本構成
+- `docker-compose_for_dev.yml` は開発用で nginx を追加
+
+## 読み始める順番
+
+1. `app.py`
+2. `templates/index.html`
+3. `templates/disease.html`
+4. `static/js/disease/`
+5. `sparqlist/repository/`
+6. `ontology/`
+
+## 注意点
+
+- コード上は `ontology/current_release/...` を参照している
+- リポジトリ上は日付付きリリースディレクトリが中心なので、`current_release` は運用時に別途用意される前提の可能性がある
+- `cgi/` は現行 Flask 本体とは別系統の補助資産に見えるため、最初の読解対象としては優先度が低い

--- a/docs/02-disease-request-flow.md
+++ b/docs/02-disease-request-flow.md
@@ -1,0 +1,90 @@
+# 疾患ページのリクエストフロー
+
+## この資料の目的
+
+NanbyoData の理解でいちばん大事なのは、`/disease/NANDO:<id>` がどう組み立てられているかです。  
+このページでは、Flask、ontology、SPARQList API、フロントエンド JavaScript が連携します。
+
+## 対象 URL
+
+- `/disease/NANDO:2200053` のような疾患詳細ページ
+
+## ひとことで言うと
+
+サーバ側で「ページの骨組みとメタ情報」を作り、クライアント側で「各セクションの詳細データ」を埋めていく構成です。
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Flask as Flask app.py
+    participant Ontology as ontology/current_release/*.obo
+    participant SPARQList as SPARQList API
+    participant JS as static/js/disease/*
+
+    Browser->>Flask: GET /disease/NANDO:<id>
+    Flask->>Flask: get_locale() で言語決定
+    Flask->>Ontology: 日本語/英語の OBO を読み込む
+    Ontology-->>Flask: 疾患階層・親子関係
+    Flask->>Flask: パンくず / セレクタ HTML を組み立てる
+    Flask->>SPARQList: nanbyodata_get_overview_by_nando_id?nando_id=<id>
+    SPARQList-->>Flask: 概要 JSON
+    Flask->>Flask: title / description を決定
+    Flask-->>Browser: disease.html を返す
+    Browser->>JS: disease系JSを実行
+    JS->>SPARQList: 各種 API を追加で呼び出す
+    SPARQList-->>JS: 遺伝子・症状・検査などの JSON
+    JS-->>Browser: 各セクションを描画・更新
+```
+
+## サーバ側でやっていること
+
+### 1. 言語を決める
+
+- `session['lang']` と `Accept-Language` を使って `ja` / `en` を決める
+- この値に応じて日本語 OBO と英語 OBO を切り替える
+
+### 2. ontology から階層を引く
+
+- `pronto` で OBO を開く
+- 対象疾患の上位概念をたどる
+- 各階層で下位疾患候補を取り、パンくず型の選択 UI を組み立てる
+
+### 3. SPARQList から概要を取る
+
+- `nanbyodata_get_overview_by_nando_id` を呼ぶ
+- タイトルや説明文を決める
+- それを `disease.html` の SEO メタ情報にも使う
+
+## クライアント側でやっていること
+
+- `templates/disease.html` が基本レイアウトを返す
+- `static/js/disease/` 配下のスクリプトが、各セクションのデータ取得やサイドナビ制御を担当する
+- つまり、初回 HTML はサーバで生成し、詳細コンテンツは JS で拡張する
+
+## 読むときの着眼点
+
+### まず確認する箇所
+
+- `app.py` の疾患ページルート
+- `app.py` の `make_selector_subclasses()`
+- `app.py` の `get_overview()`
+- `templates/disease.html`
+- `static/js/disease/`
+
+### ここが設計上のポイント
+
+- 画面表示の一部はサーバレンダリング
+- データ本体の多くは SPARQList API 依存
+- 疾患階層ナビゲーションだけはローカル ontology 依存
+
+## 理解チェック用メモ
+
+このページの不具合を切り分けるときは、まず以下のどこで止まっているかを見ると進めやすいです。
+
+1. Flask ルートに到達しているか
+2. `ontology/current_release` が正しく置かれているか
+3. `BASE_URI` が正しいか
+4. SPARQList API が返っているか
+5. `static/js/disease/` の追加描画が失敗していないか

--- a/docs/03-directory-responsibilities.md
+++ b/docs/03-directory-responsibilities.md
@@ -1,0 +1,91 @@
+# ディレクトリ責務一覧
+
+## この資料の目的
+
+NanbyoData は、アプリ本体、画面、データ資産、SPARQList、旧資産が同じリポジトリに入っています。  
+最初に「どこを編集すると何が変わるか」を把握しておくと、調査と変更がかなり楽になります。
+
+## 一覧表
+
+| パス | 主な責務 | 主に誰が使うか | 優先度 |
+| --- | --- | --- | --- |
+| `app.py` | Flask アプリ本体、ルーティング、言語切替、疾患ページ生成 | バックエンド実装者 | 高 |
+| `templates/` | 各ページの HTML テンプレート | フロントエンド実装者 | 高 |
+| `templates/component/` | ナビゲーションやフッターなどの共通部品 | フロントエンド実装者 | 中 |
+| `static/js/` | ページごとの動作、API 呼び出し、画面更新 | フロントエンド実装者 | 高 |
+| `static/sass/` | 画面スタイルのソース | フロントエンド実装者 | 中 |
+| `static/css/` | 配布用 CSS や外部由来 CSS | フロントエンド実装者 | 低 |
+| `static/img/` | 画像、ロゴ、アイコン | デザイナー / 実装者 | 低 |
+| `ontology/` | NANDO のリリースデータ一式 | データ担当 / バックエンド実装者 | 高 |
+| `annotation/` | 遺伝子・表現型などの注釈データ | データ担当 | 中 |
+| `sparqlist/repository/` | SPARQList API クエリ定義 | データ担当 / API担当 | 高 |
+| `sparqlist/docker-compose.yml` | SPARQList サービス起動設定 | 運用担当 | 中 |
+| `cgi/` | 旧 CGI やデータ変換資産 | 保守担当 | 低 |
+| `uwsgi/` | uWSGI 設定、プロセス制御 | 運用担当 | 中 |
+| `Dockerfile` | アプリイメージのビルド定義 | 運用担当 | 中 |
+| `docker-compose.yml` | 基本の起動構成 | 運用担当 | 高 |
+| `docker-compose_for_dev.yml` | 開発用起動構成、nginx 含む | 開発者 | 高 |
+| `posts/` | お知らせ記事の原稿 | コンテンツ担当 | 中 |
+
+## 用途別に見ると
+
+### 画面を直したいとき
+
+読む順番:
+
+1. `templates/`
+2. `static/js/`
+3. `static/sass/`
+
+### 疾患ページの挙動を直したいとき
+
+読む順番:
+
+1. `app.py`
+2. `templates/disease.html`
+3. `static/js/disease/`
+4. `sparqlist/repository/`
+5. `ontology/`
+
+### API やデータの中身を追いたいとき
+
+読む順番:
+
+1. `sparqlist/repository/`
+2. `ontology/`
+3. `annotation/`
+4. `app.py`
+
+### 起動やデプロイを確認したいとき
+
+読む順番:
+
+1. `README.md`
+2. `Dockerfile`
+3. `docker-compose.yml`
+4. `docker-compose_for_dev.yml`
+5. `uwsgi/uwsgi.ini`
+
+## 初見で迷いやすい点
+
+### `ontology/` は配布データでもあり、実行時参照データでもある
+
+- ダウンロード用ファイル置き場に見える一方で、疾患ページ生成にも関わる
+- 単なる静的配布物ではない
+
+### `sparqlist/` はアプリ本体ではなく、API 定義の別レイヤー
+
+- Flask 側の Python コードだけを読んでも、データ取得ロジックの全体は分からない
+- API の意味を知るには `sparqlist/repository/` まで見る必要がある
+
+### `cgi/` は最初に追わなくてよい可能性が高い
+
+- 現行の主要導線は Flask 中心
+- 調査対象が旧資産でない限り、優先順位は下げてよい
+
+## 推奨する調査スタート地点
+
+- 実装理解: `app.py`
+- 画面理解: `templates/index.html`, `templates/disease.html`
+- データ理解: `sparqlist/repository/`, `ontology/`
+- 実行理解: `docker-compose_for_dev.yml`, `uwsgi/uwsgi.ini`

--- a/docs/04-url-template-map.md
+++ b/docs/04-url-template-map.md
@@ -1,0 +1,86 @@
+# URL とテンプレート対応表
+
+## この資料の目的
+
+NanbyoData では、Flask のルート、Jinja テンプレート、フロントエンド JavaScript が比較的まっすぐ対応しています。  
+この対応表は、「ある URL を直したいときに、どのテンプレートと JS を見ればよいか」をすぐ分かるようにするためのものです。
+
+## ひと目で見る導線
+
+```mermaid
+flowchart TD
+    routes["Flask routes\napp.py"] --> pages["templates/*.html"]
+    pages --> js["static/js/*"]
+    pages --> assets["static/sass\nstatic/img"]
+    pages --> api["/sparqlist/api/*"]
+    routes --> files["ontology/\nannotation/"]
+```
+
+## URL 対応表
+
+| URL | Flask 側の役割 | テンプレート | 主な JS | 備考 |
+| --- | --- | --- | --- | --- |
+| `/` | トップページ表示 | `templates/index.html` | `static/js/main.js`, `static/js/stats-overview.js` | お知らせ、統計概要、SmartBox を表示 |
+| `/api` | API 紹介ページ表示 | `templates/api.html` | `static/js/main.js` | Swagger UI を埋め込む |
+| `/about_nanbyodata` | NanbyoData 説明ページ表示 | `templates/about_nanbyodata.html` | `static/js/main.js` | 静的説明ページ |
+| `/about_nando` | NANDO 説明ページ表示 | `templates/about_nando.html` | `static/js/main.js` | 静的説明ページ |
+| `/datasets` | データセット説明ページ表示 | `templates/datasets.html` | `static/js/main.js` | データ配布案内 |
+| `/stats` | 統計ページ表示 | `templates/stats.html` | `static/js/main.js`, `static/js/stats.js` | SPARQList API を複数呼ぶ |
+| `/team` | チームページ表示 | `templates/team.html` | `static/js/main.js`, `static/js/team/team.js` | `static/data/members.json` を読む |
+| `/epidemiology` | 疫学ページ表示 | `templates/epidemiology.html` | `static/js/main.js`, `static/js/epidemiology/epidemiology.js` | SPARQList API の患者数表を表示 |
+| `/ontology/nando` | NANDO 一覧ページ表示 | `templates/nando.html` | なし | 大きな静的 HTML に近い |
+| `/news` | お知らせ一覧表示 | `templates/news.html` | `static/js/main.js`, `static/js/news/news.js` | GitHub 上の Markdown を読む |
+| `/disease/NANDO:<id>` | 疾患詳細ページ表示 | `templates/disease.html` | `static/js/disease/disease.js` とその配下 | このシステムの中心導線 |
+| `/ontology/<path:filename>` | ontology 配布ファイルを返す | なし | なし | `send_from_directory('ontology', ...)` |
+| `/annotation/<path:filename>` | annotation 配布ファイルを返す | なし | なし | `send_from_directory('annotation', ...)` |
+| `/feedback` | フィードバック受信 | なし | なし | ログ出力のみの簡易 API |
+
+## 主要ページの見方
+
+### トップページ `/`
+
+- 最初に見るファイル:
+  - `app.py`
+  - `templates/index.html`
+  - `static/js/main.js`
+  - `static/js/stats-overview.js`
+- 役割:
+  - ナビゲーションやニュース概要の表示
+  - 統計カードの数値取得
+  - 疾患検索 SmartBox の入口
+
+### 疾患ページ `/disease/NANDO:<id>`
+
+- 最初に見るファイル:
+  - `app.py`
+  - `templates/disease.html`
+  - `static/js/disease/disease.js`
+- 役割:
+  - サーバ側で基本情報とパンくずを生成
+  - クライアント側で詳細データを取得して各セクションを描画
+
+### 統計ページ `/stats`
+
+- 最初に見るファイル:
+  - `templates/stats.html`
+  - `static/js/stats.js`
+- 役割:
+  - SPARQList API を集約して統計表を表示
+  - 複数の API の結果をひとつの画面に合成する
+
+## テンプレートと JS の対応パターン
+
+- 多くのページは `templates/*.html` と `static/js/main.js` の組み合わせ
+- データ取得が多いページだけ、専用 JS が追加される
+- そのため、変更箇所のあたりを付けるときは次の順番が効率的
+
+1. `app.py` で URL を探す
+2. 対応テンプレートを開く
+3. 読み込まれている JS を確認する
+4. その JS が呼ぶ `/sparqlist/api/*` を追う
+
+## 注意点
+
+- `templates/index.html` や `templates/disease.html` には `/download/latest/...` へのリンクがあるが、`app.py` にはそのルートが見当たらない
+- つまりダウンロード系の一部は別サーバや nginx 側で解決している可能性がある
+- `templates/nando.html` は非常に大きく、一般的なテンプレートというより生成済み HTML 資産に近い

--- a/docs/05-sparqlist-api-inventory.md
+++ b/docs/05-sparqlist-api-inventory.md
@@ -1,0 +1,135 @@
+# SPARQList API 一覧
+
+## この資料の目的
+
+NanbyoData では、画面表示の多くが `/sparqlist/api/*` に依存しています。  
+この資料では、「どの API がどの画面から使われるか」「まずどこから追うと理解しやすいか」を整理します。
+
+## API の位置づけ
+
+- Flask は画面の入口と一部の整形を担当する
+- データ本体の多くは SPARQList API から返る
+- API 定義そのものは `sparqlist/repository/*.md` にある
+
+## ひと目で見る関係
+
+```mermaid
+flowchart LR
+    disease["/disease/NANDO:<id>"] --> disease_api["Disease APIs"]
+    stats["/stats"] --> stats_api["Statistics APIs"]
+    epi["/epidemiology"] --> epi_api["Epidemiology APIs"]
+    top["/"] --> top_api["Top stats APIs"]
+
+    disease_api --> repo["sparqlist/repository/*.md"]
+    stats_api --> repo
+    epi_api --> repo
+    top_api --> repo
+```
+
+## 画面別 API 一覧
+
+### 1. 疾患ページで使う API
+
+主な呼び出し元:
+
+- `app.py`
+- `static/js/disease/disease.js`
+
+| API 名 | 主な用途 | 主な呼び出し元 |
+| --- | --- | --- |
+| `nanbyodata_get_overview_by_nando_id` | 疾患概要、タイトル、説明文 | `app.py`, `static/js/disease/disease.js` |
+| `nanbyodata_get_link_omim_by_nando_id` | OMIM 外部リンク | `static/js/disease/disease.js` |
+| `nanbyodata_get_link_orphanet_by_nando_id` | Orphanet 外部リンク | `static/js/disease/disease.js` |
+| `nanbyodata_get_link_mondo_by_nando_id` | MONDO / Monarch 系リンク | `static/js/disease/disease.js` |
+| `nanbyodata_get_link_medgen_by_nando_id` | MedGen 外部リンク | `static/js/disease/disease.js` |
+| `nanbyodata_get_link_kegg_by_nando_id` | KEGG 外部リンク | `static/js/disease/disease.js` |
+| `nanbyodata_get_japan_curated_gene_by_nando_id` | 国内基準由来の遺伝子 | `static/js/disease/disease.js` |
+| `nanbyodata_get_causal_gene_by_nando_id` | 国際リソース由来の遺伝子 | `static/js/disease/disease.js` |
+| `nanbyodata_get_glycosmos_gene_by_nando_id` | 糖鎖関連遺伝子 | `static/js/disease/disease.js` |
+| `nanbyodata_get_genetic_test_by_nando_id` | 診療用遺伝学的検査 | `static/js/disease/disease.js` |
+| `nanbyodata_get_hpo_data_by_nando_id` | 臨床的特徴 | `static/js/disease/disease.js` |
+| `nanbyodata_get_nbdc_human_databases_info_by_nando_id` | Human Genomic Datasets | `static/js/disease/disease.js` |
+| `nanbyodata_get_riken_brc_cell_info_by_nando_id` | 細胞バイオリソース | `static/js/disease/disease.js` |
+| `nanbyodata_get_riken_brc_mouse_info_by_nando_id` | マウスバイオリソース | `static/js/disease/disease.js` |
+| `nanbyodata_get_riken_brc_dna_info_by_nando_id` | DNA バイオリソース | `static/js/disease/disease.js` |
+| `nanbyodata_get_clinvar_variant_by_nando_id` | ClinVar バリアント | `static/js/disease/disease.js` |
+| `nanbyodata_get_mgend_variant_by_nando_id` | MGeND バリアント | `static/js/disease/disease.js` |
+| `nanbyodata_get_gestaltmatcher_data_by_nando_id` | 顔貌特徴 | `static/js/disease/disease.js` |
+| `nanbyodata_get_pubchem_chemical_information_by_nando_id` | 化合物情報 | `static/js/disease/disease.js` |
+| `nanbyodata_get_pubmed_data_by_nando_id` | 参考文献 | `static/js/disease/disease.js` |
+| `nanbyodata_get_stats_on_patient_number_by_nando_id` | 患者数 | `static/js/disease/disease.js` |
+| `nanbyodata_get_sub_class_by_nando_id` | 下位疾患一覧 | `static/js/disease/disease.js` |
+
+### 2. 統計ページで使う API
+
+主な呼び出し元:
+
+- `static/js/stats.js`
+
+| API 名 | 主な用途 |
+| --- | --- |
+| `NANDO_count` | 難病件数の集計 |
+| `NANDO_link_count` | 外部リンク系の集計 |
+| `NANDO_link_count2` | 遺伝子、遺伝学的検査、臨床特徴の集計 |
+| `NANDO_link_count3` | バイオリソース集計 |
+| `NANDO_link_count4` | 顔貌特徴集計 |
+| `NANDO_link_count5` | 追加統計の集計 |
+| `NANDO_link_count7` | ClinVar 系集計 |
+| `NANDO_link_count8` | 糖鎖関連遺伝子集計 |
+
+### 3. トップページの統計概要で使う API
+
+主な呼び出し元:
+
+- `static/js/stats-overview.js`
+
+| API 名 | 主な用途 |
+| --- | --- |
+| `NANDO_count` | 難病総数カード |
+| `NANDO_link_count` | 外部リンク数カード |
+| `NANDO_link_count2` | 遺伝子、検査、臨床特徴カード |
+| `NANDO_link_count3` | バイオリソースカード |
+| `NANDO_link_count4` | 顔貌特徴カード |
+| `NANDO_link_count8` | 糖鎖関連遺伝子カード |
+
+### 4. 疫学ページで使う API
+
+主な呼び出し元:
+
+- `static/js/epidemiology/epidemiology.js`
+
+| API 名 | 主な用途 |
+| --- | --- |
+| `nanbyodata_get_stats_on_patient_number_shitei` | 指定難病の患者数表 |
+| `nanbyodata_get_stats_on_patient_number_shoman` | 小児慢性特定疾病の患者数表 |
+
+## 優先して理解するとよい API
+
+初学者向けのおすすめ順は次の通りです。
+
+1. `nanbyodata_get_overview_by_nando_id`
+2. `nanbyodata_get_hpo_data_by_nando_id`
+3. `nanbyodata_get_japan_curated_gene_by_nando_id`
+4. `NANDO_count`
+5. `NANDO_link_count2`
+
+理由:
+
+- 疾患ページの中心導線と統計ページの中心導線を押さえられる
+- UI で目に見える値と対応しやすい
+- API の粒度が分かりやすい
+
+## repository の見方
+
+SPARQList API を追うときは、次の順番で見ると理解しやすいです。
+
+1. 画面側の JS で API 名を確認する
+2. `sparqlist/repository/<api名>.md` を開く
+3. 返却項目の名前を画面側の参照箇所と照合する
+4. 必要なら関連 API を横に読む
+
+## 注意点
+
+- `sparqlist/repository/` には本番利用 API 以外に、`test_*`, `shin_*`, `EX_*`, `pcf_*` など実験・補助・別用途のファイルも多い
+- そのため、最初は「画面から実際に参照されている API 名」だけに絞って追うのが安全
+- `NANDO_link_count5` など一部の API は統計画面専用で、トップページや疾患ページでは未使用のものがある

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# NanbyoData Documentation
+
+このディレクトリは、NanbyoData の構成理解を早めるための補助ドキュメントです。
+
+## 最初に読むもの
+
+1. [システム全体図](./01-system-overview.md)
+2. [疾患ページのリクエストフロー](./02-disease-request-flow.md)
+3. [ディレクトリ責務一覧](./03-directory-responsibilities.md)
+4. [URL とテンプレート対応表](./04-url-template-map.md)
+5. [SPARQList API 一覧](./05-sparqlist-api-inventory.md)
+
+## 使い分け
+
+- 全体像をつかみたいとき: `01-system-overview.md`
+- `/disease/NANDO:<id>` の動きを追いたいとき: `02-disease-request-flow.md`
+- どのファイルやディレクトリを読めばよいか迷ったとき: `03-directory-responsibilities.md`
+- URL から編集対象を逆引きしたいとき: `04-url-template-map.md`
+- SPARQList API の使われ方を追いたいとき: `05-sparqlist-api-inventory.md`


### PR DESCRIPTION
目的

NanbyoData リポジトリの全体構成や主要導線を、コードを深く読まなくても把握できるようにするため、理解用ドキュメントを追加しました。
初見の開発者や引き継ぎ時に、画面構成、データフロー、SPARQList API の使われ方を素早く追える状態にすることを目的としています。

変更内容

docs/ ディレクトリを新設し、構成理解のためのドキュメントを追加
システム全体図を追加
Flask、templates、static、ontology、annotation、SPARQList、Docker/uWSGI/nginx の関係を整理
疾患ページ /disease/NANDO:<id> のリクエストフローを追加
サーバ側処理とクライアント側処理の役割分担を Mermaid 付きで整理
ディレクトリ責務一覧を追加
主要ディレクトリ・ファイルの役割と、調査時の読み順を整理
URL とテンプレート対応表を追加
Flask ルート、対応テンプレート、関連 JS の対応関係を一覧化
SPARQList API 一覧を追加
画面ごとに利用している API を整理し、どの API から読むと理解しやすいかを明記
docs/README.md を追加し、各ドキュメントへの導線を整理
補足

追加した内容は既存コードや既存構成を整理・可視化したもので、アプリケーションの挙動変更はありません。
図はすべて Markdown / Mermaid で記述しており、今後の更新や保守がしやすい形にしています。
ドキュメント内には、ontology/current_release の扱いや /download/latest/... のように、実装読解時に迷いやすい点も注意事項として記載しています。
