### PR TITLE
Fix mobile menu on my diseases page

### DIFF
--- a/templates/my_diseases.html
+++ b/templates/my_diseases.html
@@ -71,6 +71,12 @@
     </section>
   </main>
 
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
   <script src="/static/js/utils/disease-characters.js"></script>
   <script type="module" src="/static/js/main.js"></script>
   <script src="/static/js/my_diseases.js"></script>


### PR DESCRIPTION
## Summary
- add Bootstrap JS dependencies to the my-diseases page
- fix the mobile hamburger menu so the navigation collapse opens correctly

## Testing
- verified the page loads at /my-diseases
- confirmed the Bootstrap scripts are included in the rendered HTML